### PR TITLE
Update DotNetZip to 1.10.1

### DIFF
--- a/ZlibWithDictionary/ZlibWithDictionary.csproj
+++ b/ZlibWithDictionary/ZlibWithDictionary.csproj
@@ -31,8 +31,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip, Version=1.10.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.10.0\lib\net20\Ionic.Zip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/ZlibWithDictionary/packages.config
+++ b/ZlibWithDictionary/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.10.0" targetFramework="net45" />
+  <package id="DotNetZip" version="1.10.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Right now ZlibWithDictionary doesn't work with the latest DotNetZip, because of a change in assembly name.
